### PR TITLE
Login Form Target URL defined with Environment Variable

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/zap/ZAPBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/zap/ZAPBuilder.java
@@ -139,6 +139,7 @@ public class ZAPBuilder extends Builder {
         String includedURL = zaproxy.getIncludedURL();
         String excludedURL = zaproxy.getExcludedURL();
         String targetURL = zaproxy.getTargetURL();
+        String loginURL = zaproxy.getLoginURL();
         String reportName = zaproxy.getReportFilename();
         String reportTitle = zaproxy.getExportreportTitle();
         ArrayList<ZAPCmdLine> cmdLinesZap = new ArrayList<ZAPCmdLine>(zaproxy.getCmdLinesZAP().size());
@@ -152,6 +153,7 @@ public class ZAPBuilder extends Builder {
             includedURL = applyMacro(build, listener, includedURL);
             excludedURL = applyMacro(build, listener, excludedURL);
             targetURL = applyMacro(build, listener, targetURL);
+            loginURL = applyMacro(build, listener, loginURL);
             reportName = applyMacro(build, listener, reportName);
             reportTitle = applyMacro(build, listener, reportTitle);
             for (ZAPCmdLine cmdLineZap : zaproxy.getCmdLinesZAP())
@@ -169,6 +171,7 @@ public class ZAPBuilder extends Builder {
         zaproxy.setEvaluatedIncludedURL(includedURL);
         zaproxy.setEvaluatedExcludedURL(excludedURL);
         zaproxy.setEvaluatedTargetURL(targetURL);
+        zaproxy.setEvaluatedLoginURL(loginURL);
         zaproxy.setEvaluatedReportFilename(reportName);
         zaproxy.setEvaluatedExportreportTitle(reportTitle);
         zaproxy.setEvaluatedCmdLinesZap(cmdLinesZap);
@@ -186,6 +189,7 @@ public class ZAPBuilder extends Builder {
         Utils.loggerMessage(listener, 1, "EXCLUDE FROM CONTEXT = [ {0} ]", excludedURL.trim().replace("\n", ", "));
         Utils.lineBreak(listener);
         Utils.loggerMessage(listener, 1, "STARTING POINT (URL) = [ {0} ]", targetURL);
+        Utils.loggerMessage(listener, 1, "LOGIN FORM (URL) = [ {0} ]", loginURL);
         Utils.loggerMessage(listener, 1, "REPORT FILENAME = [ {0} ]", reportName);
         Utils.loggerMessage(listener, 1, "REPORT TITLE = [ {0} ]", reportTitle);
         Utils.lineBreak(listener);

--- a/src/main/java/org/jenkinsci/plugins/zap/ZAPBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/zap/ZAPBuilder.java
@@ -189,7 +189,7 @@ public class ZAPBuilder extends Builder {
         Utils.loggerMessage(listener, 1, "EXCLUDE FROM CONTEXT = [ {0} ]", excludedURL.trim().replace("\n", ", "));
         Utils.lineBreak(listener);
         Utils.loggerMessage(listener, 1, "STARTING POINT (URL) = [ {0} ]", targetURL);
-        Utils.loggerMessage(listener, 1, "LOGIN FORM (URL) = [ {0} ]", loginURL);
+        Utils.loggerMessage(listener, 1, "LOGIN FORM TARGET (URL) = [ {0} ]", loginURL);
         Utils.loggerMessage(listener, 1, "REPORT FILENAME = [ {0} ]", reportName);
         Utils.loggerMessage(listener, 1, "REPORT TITLE = [ {0} ]", reportTitle);
         Utils.lineBreak(listener);

--- a/src/main/java/org/jenkinsci/plugins/zap/ZAPDriver.java
+++ b/src/main/java/org/jenkinsci/plugins/zap/ZAPDriver.java
@@ -558,8 +558,8 @@ public class ZAPDriver extends AbstractDescribableImpl<ZAPDriver> implements Ser
         else Utils.loggerMessage(listener, 1, "(EXP) STARTING POINT (URL) = [ {0} ]", this.evaluatedTargetURL);
 
         this.evaluatedLoginURL = envVars.expand(this.evaluatedLoginURL);
-        if (this.evaluatedLoginURL == null || this.evaluatedLoginURL.isEmpty()) throw new IllegalArgumentException("STARTING POINT (URL) IS MISSING, PROVIDED [ " + this.evaluatedLoginURL + " ]");
-        else Utils.loggerMessage(listener, 1, "(EXP) STARTING POINT (URL) = [ {0} ]", this.evaluatedLoginURL);
+        if (this.evaluatedLoginURL == null || this.evaluatedLoginURL.isEmpty()) throw new IllegalArgumentException("LOGIN FORM TARGET (URL) IS MISSING, PROVIDED [ " + this.evaluatedLoginURL + " ]");
+        else Utils.loggerMessage(listener, 1, "(EXP) LOGIN FORM TARGET (URL) = [ {0} ]", this.evaluatedLoginURL);
 
         if (this.generateReports) {
             this.evaluatedReportFilename = envVars.expand(this.evaluatedReportFilename);

--- a/src/main/java/org/jenkinsci/plugins/zap/ZAPDriver.java
+++ b/src/main/java/org/jenkinsci/plugins/zap/ZAPDriver.java
@@ -557,6 +557,10 @@ public class ZAPDriver extends AbstractDescribableImpl<ZAPDriver> implements Ser
         if (this.evaluatedTargetURL == null || this.evaluatedTargetURL.isEmpty()) throw new IllegalArgumentException("STARTING POINT (URL) IS MISSING, PROVIDED [ " + this.evaluatedTargetURL + " ]");
         else Utils.loggerMessage(listener, 1, "(EXP) STARTING POINT (URL) = [ {0} ]", this.evaluatedTargetURL);
 
+        this.evaluatedLoginURL = envVars.expand(this.evaluatedLoginURL);
+        if (this.evaluatedLoginURL == null || this.evaluatedLoginURL.isEmpty()) throw new IllegalArgumentException("STARTING POINT (URL) IS MISSING, PROVIDED [ " + this.evaluatedLoginURL + " ]");
+        else Utils.loggerMessage(listener, 1, "(EXP) STARTING POINT (URL) = [ {0} ]", this.evaluatedLoginURL);
+
         if (this.generateReports) {
             this.evaluatedReportFilename = envVars.expand(this.evaluatedReportFilename);
             if (this.evaluatedReportFilename == null || this.evaluatedReportFilename.isEmpty()) throw new IllegalArgumentException("REPORT FILENAME IS MISSING, PROVIDED [ " + this.evaluatedReportFilename + " ]");
@@ -1180,8 +1184,8 @@ public class ZAPDriver extends AbstractDescribableImpl<ZAPDriver> implements Ser
                 Utils.loggerMessage(listener, 0, "[{0}] AUTHENTICATION MODE [ {1} ]", Utils.ZAP, this.authMethod.toUpperCase());
                 Utils.lineBreak(listener);
                 /* SETUP AUTHENICATION */
-                if (this.authMode) if (this.authMethod.equals(FORM_BASED)) this.userId = setUpAuthentication(listener, clientApi, this.contextId, this.loginURL, this.username, this.password, this.loggedInIndicator, this.loggedOutIndicator, this.extraPostData, this.authMethod, this.usernameParameter, this.passwordParameter, null, null);
-                else if (this.authMethod.equals(SCRIPT_BASED)) this.userId = setUpAuthentication(listener, clientApi, this.contextId, this.loginURL, this.username, this.password, this.loggedInIndicator, this.loggedOutIndicator, this.extraPostData, this.authMethod, null, null, this.authScript, this.authScriptParams);
+                if (this.authMode) if (this.authMethod.equals(FORM_BASED)) this.userId = setUpAuthentication(listener, clientApi, this.contextId, this.evaluatedLoginURL, this.username, this.password, this.loggedInIndicator, this.loggedOutIndicator, this.extraPostData, this.authMethod, this.usernameParameter, this.passwordParameter, null, null);
+                else if (this.authMethod.equals(SCRIPT_BASED)) this.userId = setUpAuthentication(listener, clientApi, this.contextId, this.evaluatedLoginURL, this.username, this.password, this.loggedInIndicator, this.loggedOutIndicator, this.extraPostData, this.authMethod, null, null, this.authScript, this.authScriptParams);
 
                 /* SETUP ATTACK MODES */
                 Utils.lineBreak(listener);
@@ -2924,6 +2928,12 @@ public class ZAPDriver extends AbstractDescribableImpl<ZAPDriver> implements Ser
     private final String loginURL; /* Login URL. */
 
     public String getLoginURL() { return loginURL; }
+
+    private String evaluatedLoginURL; /* Todo */
+
+    public String getEvaluatedLoginURL() { return evaluatedLoginURL; }
+
+    public void setEvaluatedLoginURL(String evaluatedLoginURL) { this.evaluatedLoginURL = evaluatedLoginURL; }
 
     private final String usernameParameter; /* username post data parameter (form based authentication). */
 


### PR DESCRIPTION
When configuring Form-based Authentication, a user is unable to specify an environment variable in the Login Form Target URL field. This pull request allows an environment variable to be specified and expanded in that field.

This is a fix for JENKINS-47038.