### PR TITLE
Pass auth script name without extension to zap API

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/zap/ZAPDriver.java
+++ b/src/main/java/org/jenkinsci/plugins/zap/ZAPDriver.java
@@ -1501,7 +1501,8 @@ public class ZAPDriver extends AbstractDescribableImpl<ZAPDriver> implements Ser
 
         /* Prepare the configuration in a format similar to how URL parameters are formed. This means that any value we add for the configuration values has to be URL encoded. */
         StringBuilder scriptBasedConfig = new StringBuilder();
-        scriptBasedConfig.append("scriptName=").append(URLEncoder.encode(scriptName, "UTF-8"));
+        scriptBasedConfig.append("scriptName=").append(URLEncoder.encode(
+                scriptName.replace(FILE_AUTH_SCRIPTS_JS_EXTENSION,"").replace(FILE_AUTH_SCRIPTS_ZEST_EXTENSION,""), "UTF-8"));
         if (!authScriptParams.isEmpty()) addZAPAuthScriptParam(authScriptParams, scriptBasedConfig);
 
         /*


### PR DESCRIPTION
Recorder auth scripts should be passed to zap API by name only without extention, since  when its actually using them it tries to match the name from config xml to the one passed in scriptName param.

![script-name](https://user-images.githubusercontent.com/16775850/38305828-386a1110-3806-11e8-90f9-8f04f77dc990.png)

Refer to SctiptTreeModel.java - line 189
```
if (((ScriptWrapper)scriptNode.getUserObject()).getName().equals(name)) {
    return (ScriptWrapper)scriptNode.getUserObject();
}
```
but when setting scriptName argument in jenkins plugin the name of the script is passed with .zst/.js extension which causes failure:

```
"Unable to find script while loading Script Based Authentication Method for name: test.zst
```
