### PR TITLE
Update ZAP API client to 1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.zaproxy</groupId>
       <artifactId>zap-clientapi</artifactId>
-      <version>1.1.1</version>
+      <version>1.6.0</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Address an issue reported in the mailing list and zaproxy issue tracker
where the Jenkins plugin was not able, in some cases, to obtain the
latest status of the spider.

zaproxy/zaproxy#4462 - ZAP Jenkins plugin does not obtain latest spider
status