### PR TITLE
JENKINS-63395 - Move ZAP Proxy object initialisation to just prior to

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,11 @@
           <additionalparam>-Xdoclint:none</additionalparam>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <version>3.0.5</version>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Move ZAP Proxy object initialisation to just prior to the ZAP Proxy being started to ensure that correct variable substitution
takes place.